### PR TITLE
Introduce full stdbool.h implementation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,3 +23,4 @@ jobs:
         run: |
           python ./autobot --test crt
           python ./autobot --test stdint
+          python ./autobot --test stdbool

--- a/include/stdbool.h
+++ b/include/stdbool.h
@@ -1,0 +1,22 @@
+/**
+ * @file include/stdbool.h
+ * @brief Standard boolean type definitions.
+ * 
+ * Defines the boolean type and its values for the CILibc.
+ * 
+ * @see https://pubs.opengroup.org/onlinepubs/9799919799/
+ * 
+ * @author Ismael Moreira
+ */
+#ifndef __CILIBC__STANDARD_BOOLEAN__
+#define __CILIBC__STANDARD_BOOLEAN__
+
+/**
+ * @typedef bool
+ * @brief Boolean type.
+ * 
+ * This type is used to represent boolean values in CILibc.
+ */
+typedef _Bool bool;
+
+#endif // __CILIBC__STANDARD_BOOLEAN__

--- a/include/stdbool.h
+++ b/include/stdbool.h
@@ -19,4 +19,21 @@
  */
 typedef _Bool bool;
 
+
+/**
+ * @def true
+ * @brief Boolean true value.
+ * 
+ * Represents the true value in boolean expressions.
+ */
+#define true 1
+
+/**
+ * @def false
+ * @brief Boolean false value.
+ * 
+ * Represents the false value in boolean expressions.
+ */
+#define false 0
+
 #endif // __CILIBC__STANDARD_BOOLEAN__

--- a/include/stdbool.h
+++ b/include/stdbool.h
@@ -1,11 +1,11 @@
 /**
  * @file include/stdbool.h
  * @brief Standard boolean type definitions.
- * 
+ *
  * Defines the boolean type and its values for the CILibc.
- * 
+ *
  * @see https://pubs.opengroup.org/onlinepubs/9799919799/
- * 
+ *
  * @author Ismael Moreira
  */
 #ifndef __CILIBC__STANDARD_BOOLEAN__
@@ -14,16 +14,15 @@
 /**
  * @typedef bool
  * @brief Boolean type.
- * 
+ *
  * This type is used to represent boolean values in CILibc.
  */
 typedef _Bool bool;
 
-
 /**
  * @def true
  * @brief Boolean true value.
- * 
+ *
  * Represents the true value in boolean expressions.
  */
 #define true 1
@@ -31,9 +30,18 @@ typedef _Bool bool;
 /**
  * @def false
  * @brief Boolean false value.
- * 
+ *
  * Represents the false value in boolean expressions.
  */
 #define false 0
+
+/**
+ * @def __bool_true_false_are_defined
+ * @brief Indicates that the boolean type and values are defined.
+ *
+ * This macro is defined to indicate that the boolean type and its values
+ * are available in the CILibc.
+ */
+#define __bool_true_false_are_defined 1
 
 #endif // __CILIBC__STANDARD_BOOLEAN__

--- a/scripts/testing/stdbool.py
+++ b/scripts/testing/stdbool.py
@@ -32,6 +32,22 @@ class TestStdBool(unittest.TestCase):
         self.assertEqual(stdout.strip(), "")
         self.assertEqual(stderr, "")
 
+    def testBoolTrueFalseAreDefined(self):
+        """
+        Test that the macro __bool_true_false_are_defined is well defined.
+        """
+        result: CompletedProcess = run(
+            ["__build/test/booltruefalsearedefined"], capture_output=True, text=True
+        )
+
+        stdout: Any = result.stdout
+        stderr: Any = result.stderr
+        exitCode: int = result.returncode
+
+        self.assertEqual(exitCode, 0)
+        self.assertEqual(stdout.strip(), "")
+        self.assertEqual(stderr, "")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/testing/stdbool.py
+++ b/scripts/testing/stdbool.py
@@ -1,0 +1,37 @@
+"""
+@file stdbool.py
+@brief Unit tests for the stdbool module.
+
+This module contains unit tests for the stdbool module, which provides
+boolean operations and utilities.
+"""
+from subprocess import run, CompletedProcess
+from typing import Any, List
+import unittest
+import os
+
+
+class TestStdBool(unittest.TestCase):
+    """
+    Unit tests for the stdbool module.
+    """
+
+    def testBool(self):
+        """
+        Test that bool operations work correctly.
+        """
+        result: CompletedProcess = run(
+            ["__build/test/bool"], capture_output=True, text=True
+        )
+
+        stdout: Any = result.stdout
+        stderr: Any = result.stderr
+        exitCode: int = result.returncode
+
+        self.assertEqual(exitCode, 0)
+        self.assertEqual(stdout.strip(), "")
+        self.assertEqual(stderr, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/stdbool/bool.test.c
+++ b/tests/stdbool/bool.test.c
@@ -1,0 +1,43 @@
+/**
+ * @file tests/stdbool/bool.test.c
+ * @brief Test for the boolean type and values in CILibc.
+ *
+ * This test checks the functionality of the boolean type and its values
+ * defined in the CILibc standard library. It verifies that the boolean
+ * type can be used in a simple loop and that the values true and false
+ * behave as expected.
+ *
+ * @see https://pubs.opengroup.org/onlinepubs/9799919799/
+ * @see include/stdbool.h
+ *
+ * @author Ismael Moreira
+ */
+#include "stdbool.h"
+
+/**
+ * @brief Main function for the boolean test.
+ *
+ * This function tests the boolean type by using it in a loop that
+ * iterates 10 times. It checks if the iterator reaches the expected
+ * value of 10, indicating that the boolean type and its values are
+ * functioning correctly.
+ *
+ * @return 0 on success, 1 on failure.
+ */
+int main(void)
+{
+    bool is_true = true;
+    int iterator = 0;
+
+    while (is_true) {
+        iterator++;
+
+        if (iterator >= 10)
+            is_true = false;
+    }
+
+    if (iterator != 10)
+        return 1;
+
+    return 0;
+}

--- a/tests/stdbool/booltruefalsearedefined.test.c
+++ b/tests/stdbool/booltruefalsearedefined.test.c
@@ -1,0 +1,30 @@
+/**
+ * @file tests/stdbool/booltruefalsearedefined.test.c
+ * @brief Test for the __bool_true_false_are_defined macro in CILibc.
+ *
+ * This test checks if the macro __bool_true_false_are_defined is defined,
+ * indicating that the boolean type and its values are available in the CILibc.
+ *
+ * @see https://pubs.opengroup.org/onlinepubs/9799919799/
+ * @see include/stdbool.h
+ *
+ * @author Ismael Moreira
+ */
+#include "stdbool.h"
+
+/**
+ * @brief Main function for the __bool_true_false_are_defined test.
+ *
+ * This function checks if the macro __bool_true_false_are_defined is defined.
+ * If it is not defined, the function returns 1, indicating a failure.
+ *
+ * @return 0 on success, 1 on failure.
+ */
+int main(void)
+{
+#if !defined(__bool_true_false_are_defined)
+    return 1; // The macro should be defined
+#endif
+
+    return 0;
+}


### PR DESCRIPTION
### Context

This pull request introduces the implementation of the standard <stdbool.h> header, as defined in the C99 standard and required by POSIX. It provides boolean type support in CILibc and ensures compatibility with modern C codebases that rely on bool, true, and false.

### What’s Changed

- **New Header:** include/stdbool.h
- **Definitions added:**
    - typedef _Bool bool
    - #define true 1
    - #define false 0
    - #define __bool_true_false_are_defined 1
- **C Tests:**
    - tests/stdbool/bool.test.c: tests bool, true, and false runtime behavior.
    - tests/stdbool/booltruefalsearedefined.test.c: checks if __bool_true_false_are_defined is correctly set.
- **Python Test Automation (autobot):**
    - testBool(): validates loop logic using bool.
    - testBoolTrueFalseAreDefined(): asserts the macro is correctly defined.

### Additional Notes

- Fully compliant with the POSIX specification for <stdbool.h>.
- Minimalist and header-only implementation, no runtime dependency.
- Targets C99 and later only; legacy fallback for C89 is intentionally omitted at this stage.
- Tests return 0 on success, 1 on failure, making integration with test runners straightforward.
